### PR TITLE
Store file paths to uploaded files in POSIX format

### DIFF
--- a/src/utils/pinata.ts
+++ b/src/utils/pinata.ts
@@ -34,7 +34,7 @@ async function upload(filePath: string, key: string) {
             readDirRecursively(fullPath);
           } else {
             const fileContent = fs.readFileSync(fullPath);
-            const relativePath = path.relative(absolutePath, fullPath);
+            const relativePath = path.posix.normalize(path.relative(absolutePath, fullPath).replace(/\\/g, '/'));
             const file = new File([fileContent], relativePath);
             files.push(file);
           }


### PR DESCRIPTION
Address incompatibility of win32 file paths when uploading files to Orbiter site on Pinata. Attempted fix for issue #3.